### PR TITLE
Handle external url with <a> instead of Next Link

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -3,7 +3,6 @@ import Header from '@components/Header'
 import Footer from '@components/Footer'
 import dayjs from "dayjs";
 import relativeTime from "dayjs/plugin/relativeTime";
-import Link from 'next/link';
 import Metrics from '@components/Metrics';
 import AggregateData from '../public/data/aggregate.json'
 
@@ -20,7 +19,7 @@ export default function Home() {
       <main>
         <Header title="GameStop NFT Marketplace Metrics" />
         <p className="description">
-          <Link href={'https://nft.gamestop.com'}>GameStop NFT Marketplace</Link> launched {duration}.
+          <a href={'https://nft.gamestop.com'} target="_blank">GameStop NFT Marketplace</a> launched {duration}.
         </p>
         <Metrics totalCollections={AggregateData.totalCollections} totalCount={AggregateData.totalCount} totalVolume={AggregateData.totalVolumeETH}></Metrics>
         <p>Last updated at 15/07/2022 09:00 EST</p>


### PR DESCRIPTION
The Next Link component is used to enable client-side transitions between routes of the same app but in this case we are linking to an external page, therefore an <a> is better suited. 
The target blank attribute to open a new page is also a good functionality because you may want to keep this page open and open the GameStop NFT url in another window.